### PR TITLE
Update `jekyll-theme-chirpy` to ~> 7.5 (>= 7.5.0)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "jekyll-theme-chirpy", "~> 7.2", ">= 7.2.3"
+gem "jekyll-theme-chirpy", "~> 7.5", ">= 7.5.0"
 gem 'jekyll-admin', group: :jekyll_plugins
 gem "html-proofer", "~> 5.0", group: :test
 


### PR DESCRIPTION
### Motivation
- Update the site theme dependency to pick up fixes and improvements in the newer `jekyll-theme-chirpy` release.

### Description
- Bumped `jekyll-theme-chirpy` in the `Gemfile` from `~> 7.2`, `>= 7.2.3` to `~> 7.5`, `>= 7.5.0`.

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4ff80d61c8322b6c389ecdf99f41d)