### PR TITLE
Improve indexability and sitemap generation; add SEO metadata for archive and static pages

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,0 +1,140 @@
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+  <meta name="theme-color" media="(prefers-color-scheme: light)" content="#f7f7f7">
+  <meta name="theme-color" media="(prefers-color-scheme: dark)" content="#1b1b1e">
+  <meta name="mobile-web-app-capable" content="yes">
+  <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+  <meta
+    name="viewport"
+    content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover"
+  >
+
+  {%- capture seo_tags -%}
+    {% seo title=false %}
+  {%- endcapture -%}
+
+  <!-- Setup Open Graph image -->
+
+  {% if page.image %}
+    {% assign src = page.image.path | default: page.image %}
+
+    {% unless src contains '://' %}
+      {%- capture img_url -%}
+        {% include media-url.html src=src subpath=page.media_subpath absolute=true %}
+      {%- endcapture -%}
+
+      {%- capture old_url -%}{{ src | absolute_url }}{%- endcapture -%}
+      {%- capture new_url -%}{{ img_url }}{%- endcapture -%}
+
+      {% assign seo_tags = seo_tags | replace: old_url, new_url %}
+    {% endunless %}
+
+  {% elsif site.social_preview_image %}
+    {%- capture img_url -%}
+      {% include media-url.html src=site.social_preview_image absolute=true %}
+    {%- endcapture -%}
+
+    {%- capture og_image -%}
+      <meta property="og:image" content="{{ img_url }}" />
+    {%- endcapture -%}
+
+    {%- capture twitter_image -%}
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta property="twitter:image" content="{{ img_url }}" />
+    {%- endcapture -%}
+
+    {% assign old_meta_clip = '<meta name="twitter:card" content="summary" />' %}
+    {% assign new_meta_clip = og_image | append: twitter_image %}
+    {% assign seo_tags = seo_tags | replace: old_meta_clip, new_meta_clip %}
+  {% endif %}
+
+  {{ seo_tags }}
+
+  {%- if site.social.fediverse_handle %}
+    <!-- Fediverse handle/creator -->
+    <meta name="fediverse:creator" content="{{ site.social.fediverse_handle }}">
+  {% endif %}
+
+  <title>
+    {%- unless page.layout == 'home' -%}
+      {%- capture title -%}
+        {%- if page.collection == 'tabs' -%}
+          {%- assign tab_key = page.title | downcase -%}
+          {%- assign localized_tab = site.data.locales[include.lang].tabs[tab_key] -%}
+          {{- localized_tab | default: page.title -}}
+        {%- else -%}
+          {{- page.title -}}
+        {%- endif -%}
+      {%- endcapture -%}
+      {{- title | append: ' | ' -}}
+    {%- endunless -%}
+    {{- site.title -}}
+  </title>
+
+  {% include_cached favicons.html %}
+
+  <!-- Resource Hints -->
+  {% unless site.assets.self_host.enabled %}
+    {% for hint in site.data.origin.cors.resource_hints %}
+      {% for link in hint.links %}
+        <link rel="{{ link.rel }}" href="{{ hint.url }}" {{ link.opts | join: ' ' }}>
+      {% endfor %}
+    {% endfor %}
+  {% endunless %}
+
+  <!-- Bootstrap -->
+  {% unless jekyll.environment == 'production' %}
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.8/dist/css/bootstrap.min.css">
+  {% endunless %}
+
+  <!-- Theme style -->
+  <link rel="stylesheet" href="{{ '/assets/css/:THEME.css' | replace: ':THEME', site.theme | relative_url }}">
+
+  <!-- Web Font -->
+  <link rel="stylesheet" href="{{ site.data.origin[type].webfonts | relative_url }}">
+
+  <!-- Font Awesome Icons -->
+  <link rel="stylesheet" href="{{ site.data.origin[type].fontawesome.css | relative_url }}">
+
+  <!-- 3rd-party Dependencies -->
+
+  {% if site.toc and page.toc %}
+    <link rel="stylesheet" href="{{ site.data.origin[type].toc.css | relative_url }}">
+  {% endif %}
+
+  {% if page.layout == 'post' or page.layout == 'page' or page.layout == 'home' %}
+    <link rel="stylesheet" href="{{ site.data.origin[type]['lazy-polyfill'].css | relative_url }}">
+  {% endif %}
+
+  {% if page.layout == 'page' or page.layout == 'post' %}
+    <!-- Image Popup -->
+    <link rel="stylesheet" href="{{ site.data.origin[type].glightbox.css | relative_url }}">
+  {% endif %}
+
+  <!-- Scripts -->
+
+  <script src="{{ '/assets/js/dist/theme.min.js' | relative_url }}"></script>
+
+  {% include js-selector.html lang=lang %}
+
+  {% if jekyll.environment == 'production' %}
+    <!-- PWA -->
+    {% if site.pwa.enabled %}
+      <script
+        defer
+        src="{{ '/app.min.js' | relative_url }}?baseurl={{ site.baseurl | default: '' }}&register={{ site.pwa.cache.enabled }}"
+      ></script>
+    {% endif %}
+
+    <!-- Web Analytics -->
+    {% for analytics in site.analytics %}
+      {% capture str %}{{ analytics }}{% endcapture %}
+      {% assign platform = str | split: '{' | first %}
+      {% if site.analytics[platform].id and site.analytics[platform].id != empty %}
+        {% include analytics/{{ platform }}.html %}
+      {% endif %}
+    {% endfor %}
+  {% endif %}
+
+  {% include metadata-hook.html %}
+</head>

--- a/_includes/metadata-hook.html
+++ b/_includes/metadata-hook.html
@@ -1,8 +1,5 @@
 <meta name="msvalidate.01" content="820A985B0C50C9563C5719E6D8121F1E" />
 
-<!-- Fix viewport: remove user-scalable=no (WCAG violation), ensure correct comma separation -->
-<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover">
-
 <!-- Security meta tags (GitHub Pages cannot set response headers) -->
 <meta http-equiv="X-Content-Type-Options" content="nosniff">
 <meta name="referrer" content="strict-origin-when-cross-origin">

--- a/_plugins/archive_seo_metadata.rb
+++ b/_plugins/archive_seo_metadata.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+# Give generated taxonomy archive pages unique metadata so they are less likely
+# to look like thin duplicates in Search Console.
+Jekyll::Hooks.register :pages, :pre_render do |page|
+  case page.url
+  when %r{\A/categories/([^/]+)/\z}
+    label = Regexp.last_match(1).tr("-", " ").split.map(&:capitalize).join(" ")
+    page.data["description"] ||= "Browse #{label} articles by Khushal Jethava, including practical Python, AI, machine learning, and developer-focused tutorials."
+  when %r{\A/tags/([^/]+)/\z}
+    label = Regexp.last_match(1).tr("-", " ")
+    page.data["description"] ||= "Read Khushal Jethava tutorials tagged #{label}, with hands-on guidance for Python developers and AI builders."
+  when "/archives/"
+    page.data["description"] ||= "Explore the complete archive of Khushal Jethava articles, Python tutorials, AI guides, and machine learning engineering notes."
+  when "/categories/"
+    page.data["description"] ||= "Browse all article categories on Khushal Jethava, from Python basics and reference guides to AI, LLMs, RAG, and MLOps."
+  when "/tags/"
+    page.data["description"] ||= "Browse all article tags on Khushal Jethava to find Python, AI, machine learning, LLM, RAG, and developer tutorials."
+  end
+end

--- a/_plugins/image_sitemap.rb
+++ b/_plugins/image_sitemap.rb
@@ -1,21 +1,46 @@
 # frozen_string_literal: true
 
+require "erb"
 require "rexml/document"
+require "rexml/formatters/default"
 
 # Add <image:image> elements to sitemap.xml for posts with hero images.
 # This helps Google Image Search discover and index post images.
 
 Jekyll::Hooks.register :site, :post_write do |site|
-  path = File.join(site.dest, "sitemap.xml")
-  next unless File.file?(path)
+  sitemap_path = File.join(site.dest, "sitemap.xml")
+  next unless File.file?(sitemap_path)
 
-  doc = REXML::Document.new(File.read(path))
+  doc = REXML::Document.new(File.read(sitemap_path))
   root = doc.root
   next unless root&.name == "urlset"
 
   # Add image namespace if not present
   unless root.attributes["xmlns:image"]
     root.add_namespace("image", "http://www.google.com/schemas/sitemap-image/1.1")
+  end
+
+  site_url = site.config["url"].to_s.chomp("/")
+
+  encode_absolute_url = lambda do |input|
+    value = input.to_s.strip
+    next value if value.empty?
+
+    if value.start_with?("http://", "https://")
+      uri = value
+    else
+      uri = site_url + (value.start_with?("/") ? value : "/#{value}")
+    end
+
+    uri.sub(%r{\A(https?://[^/]+)(/.*)?\z}) do
+      host = Regexp.last_match(1)
+      path_with_query = Regexp.last_match(2).to_s
+      url_path, query = path_with_query.split("?", 2)
+      encoded_path = url_path.split("/", -1).map do |part|
+        part.empty? ? part : ERB::Util.url_encode(part).tr("+", "%20")
+      end.join("/")
+      query ? "#{host}#{encoded_path}?#{query}" : "#{host}#{encoded_path}"
+    end
   end
 
   # Build a lookup of post URLs to their image paths
@@ -29,9 +54,9 @@ Jekyll::Hooks.register :site, :post_write do |site|
 
     img_alt = img.is_a?(Hash) ? img["alt"] : nil
 
-    post_url = site.config["url"].to_s + post.url
+    post_url = encode_absolute_url.call(post.url)
     post_images[post_url.chomp("/")] = {
-      "loc" => site.config["url"].to_s + img_path,
+      "loc" => encode_absolute_url.call(img_path),
       "title" => img_alt || post.data["title"]
     }
   end
@@ -40,8 +65,14 @@ Jekyll::Hooks.register :site, :post_write do |site|
     loc_el = url_el.elements["loc"]
     next unless loc_el
 
-    loc = loc_el.text.to_s.strip.chomp("/")
+    loc_el.text = encode_absolute_url.call(loc_el.text)
+    loc = loc_el.text.to_s.chomp("/")
     img_data = post_images[loc]
+
+    url_el.each_element("image:image/image:loc") do |img_loc_el|
+      img_loc_el.text = encode_absolute_url.call(img_loc_el.text)
+    end
+
     next unless img_data
 
     # Skip if image element already exists
@@ -57,7 +88,8 @@ Jekyll::Hooks.register :site, :post_write do |site|
     end
   end
 
-  File.open(path, "w") do |f|
-    doc.write(f, 2)
+  File.open(sitemap_path, "w") do |f|
+    REXML::Formatters::Default.new.write(doc, f)
+    f.write("\n")
   end
 end

--- a/_plugins/sitemap_deduplicate.rb
+++ b/_plugins/sitemap_deduplicate.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rexml/document"
+require "rexml/formatters/default"
 
 # jekyll-archives creates one archive page per distinct tag string; slug collisions
 # (e.g. "AI" vs "ai" both -> /tags/ai/) produce duplicate <loc> entries in
@@ -19,18 +20,19 @@ Jekyll::Hooks.register :site, :post_write do |site|
   root.each_element("url") do |url_el|
     loc_el = url_el.elements["loc"]
     next unless loc_el
+
     loc = loc_el.text.to_s.strip
+    loc_el.text = loc
     if seen[loc]
       to_remove << url_el
     else
       seen[loc] = true
     end
   end
-  next if to_remove.empty?
-
   to_remove.each { |el| el.parent.delete(el) }
 
   File.open(path, "w") do |f|
-    doc.write(f, 2)
+    REXML::Formatters::Default.new.write(doc, f)
+    f.write("\n")
   end
 end

--- a/_tabs/Terms and Conditions.md
+++ b/_tabs/Terms and Conditions.md
@@ -1,4 +1,6 @@
 ---
+title: Terms and Conditions
+description: "Terms and Conditions for using Khushal Jethava, including service rules, links, liability, and contact details."
 # the default layout is 'page'
 icon: fas fa-info-circle
 order: 7

--- a/_tabs/archives.md
+++ b/_tabs/archives.md
@@ -1,4 +1,6 @@
 ---
+title: Archives
+description: "Explore the complete archive of Khushal Jethava articles, Python tutorials, AI guides, and machine learning engineering notes."
 layout: archives
 icon: fas fa-archive
 order: 3

--- a/_tabs/categories.md
+++ b/_tabs/categories.md
@@ -1,4 +1,6 @@
 ---
+title: Categories
+description: "Browse all article categories on Khushal Jethava, from Python basics and reference guides to AI, LLMs, RAG, and MLOps."
 layout: categories
 icon: fas fa-stream
 order: 1

--- a/_tabs/contact-us.md
+++ b/_tabs/contact-us.md
@@ -1,10 +1,11 @@
 ---
+title: Contact Us
+description: "Contact Khushal Jethava for AI, Python, machine learning, computer vision, and software engineering questions or collaborations."
 # the default layout is 'page'
 icon: fas fa-info-circle
 order: 8
 ---
 
-<title>Contact Us</title>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/emailjs-com/3.2.0/email.min.js"></script>
   <style>
       * {

--- a/_tabs/privacy-policy.md
+++ b/_tabs/privacy-policy.md
@@ -1,4 +1,6 @@
 ---
+title: Privacy Policy
+description: "Privacy Policy for Khushal Jethava, explaining what personal information is collected, processed, shared, and protected."
 # the default layout is 'page'
 icon: fas fa-info-circle
 order: 6

--- a/_tabs/tags.md
+++ b/_tabs/tags.md
@@ -1,4 +1,6 @@
 ---
+title: Tags
+description: "Browse all article tags on Khushal Jethava to find Python, AI, machine learning, LLM, RAG, and developer tutorials."
 layout: tags
 icon: fas fa-tags
 order: 2


### PR DESCRIPTION
### Motivation
- Google Search Console reported many pages as “Discovered - currently not indexed”; investigation showed malformed/whitespace-containing sitemap entries and thin/duplicate archive metadata and some static tab pages lacking explicit titles/descriptions. 
- Fix sitemap formatting and add unique metadata so crawlers receive compact, encoded URLs and pages present clearer, non-duplicate signals to search engines.

### Description
- Normalize and percent-encode absolute sitemap URLs and image URLs and ensure sitemap is written with a proper XML formatter to avoid whitespace/encoding issues (`_plugins/image_sitemap.rb`).
- Trim and deduplicate `<loc>` entries and write the sitemap with a safe XML formatter to avoid duplicate entries that break Search Console (`_plugins/sitemap_deduplicate.rb`).
- Add a new hook that injects meaningful `description` metadata for generated archive/category/tag pages to reduce thin/duplicate metadata signals (`_plugins/archive_seo_metadata.rb`).
- Add explicit `title` and `description` front-matter to static tab pages that were flagged (Terms and Conditions, Contact, Archives, Categories, Privacy Policy, Tags) so they render proper meta descriptions and browser titles (`_tabs/*.md`).
- Override the theme `head` include to fix the tab-title fallback for custom tabs and consolidate the corrected viewport meta, and remove the duplicate viewport injection from the metadata hook (`_includes/head.html`, `_includes/metadata-hook.html`).

### Testing
- Built the site with `JEKYLL_ENV=production bundle exec jekyll build` and the build completed successfully.
- Ran the site test harness `bash tools/test.sh` (uses `html-proofer`) and it finished with no failures.
- Ran a custom sitemap audit against `_site/sitemap.xml` which reported `354` sitemap URLs, `354` unique URLs, and confirmed `0` whitespace/encoding issues in page and image `<loc>` entries.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fad2a47b40832293a399052ed91fb1)