### PR TITLE
Fix Liquid syntax warnings and broken SEO front matter

### DIFF
--- a/_posts/2025-01-03-Page 24 - Python format().md
+++ b/_posts/2025-01-03-Page 24 - Python format().md
@@ -238,7 +238,7 @@ print(log_entry)
 
 ## Edge Cases and Gotchas
 
-- **Literal braces**: To include `{` or `}` in the output, double them: `{{` and `}}`.
+- **Literal braces**: To include `{` or `}` in the output, double them: {% raw %}`{{` and `}}`{% endraw %}.
 - **f-strings vs `.format()`**: F-strings are evaluated immediately where defined; `.format()` is better for reusable templates stored in variables or config files.
 - **Missing arguments**: Referencing `{0}` with only one argument raises `IndexError`.
 - **Type mismatch**: Passing a string to a numeric format spec like `{:d}` raises `ValueError`.
@@ -251,7 +251,7 @@ print(log_entry)
 2. **Use `:.2f` for currency** to always show exactly two decimal places.
 3. **Prefer f-strings for simple inline formatting** in Python 3.6+ — they are faster and cleaner.
 4. **Use `.format()` for templates in variables** since f-strings evaluate immediately at definition.
-5. **Escape braces with doubling** (`{{`, `}}`) when the output needs literal curly brace characters.
+5. **Escape braces with doubling** ({% raw %}`{{`, `}}`{% endraw %}) when the output needs literal curly brace characters.
 
 ---
 
@@ -271,7 +271,7 @@ Both use the same format specification mini-language. F-strings (`f"Hello {name}
 
 **Q2: How do I include a literal `{` or `}` in a formatted string?**
 
-Double the brace: `{{` produces `{` and `}}` produces `}`. For example, `"{{score: {}}}".format(42)` produces `"{score: 42}"`.
+Double the brace: {% raw %}`{{` produces `{` and `}}` produces `}`. For example, `"{{score: {}}}".format(42)`{% endraw %} produces `"{score: 42}"`.
 
 **Q3: Can I use `format()` to format dates and times?**
 

--- a/_posts/2025-04-05-How-to-Extract-Chrome-Password-in-Python.md
+++ b/_posts/2025-04-05-How-to-Extract-Chrome-Password-in-Python.md
@@ -1,12 +1,12 @@
 ---
-title: # How to Extract Chrome Password in Python
-description: # How to Extract Chrome Password in Python
+title: "How to Extract Chrome Password in Python"
+description: "Learn how to extract Chrome passwords using Python in this comprehensive guide. Unlock the secrets of password extraction and enhance your coding skills."
 date: 2025-04-05 12:21:06 +0800
 categories: [Python]
 tags: [python]
 image:
   path: "/commons/How to Extract Chrome Password in Python.webp"
-  alt: # How to Extract Chrome Password in Python
+  alt: "How to Extract Chrome Password in Python"
 ---
 
 Keyword: How to Extract Chrome Password in Python  

--- a/_posts/2026-06-19-Building-a-RAG-Evaluation-Pipeline-with-Python.md
+++ b/_posts/2026-06-19-Building-a-RAG-Evaluation-Pipeline-with-Python.md
@@ -83,7 +83,7 @@ client = OpenAI()
 
 def check_faithfulness(answer: str, context: str) -> dict:
     prompt = f"""Given the CONTEXT below, determine if the ANSWER is fully supported by it.
-Reply in JSON: {{"faithful": true/false, "unsupported_claims": ["..."]}}
+Reply in JSON: {% raw %}{{"faithful": true/false, "unsupported_claims": ["..."]}}{% endraw %}
 
 CONTEXT: {context}
 ANSWER: {answer}


### PR DESCRIPTION
## Summary

Cleans up the non-fatal warnings surfaced by the production Jekyll build.

- **Liquid syntax warnings** — Literal `{{ }}` braces in prose/code (the Python `format()` post and the RAG evaluation post) were being parsed as Liquid. Wrapped the affected spans in `{% raw %}…{% endraw %}` so Liquid leaves them alone. The rendered output is unchanged.
- **Broken SEO front matter** — In `2025-04-05-How-to-Extract-Chrome-Password-in-Python.md`, the `title`, `description`, and `alt` values started with `#`, which YAML treats as a comment — so all three were effectively empty (this is what tripped the "front matter `image` has no alt text" warning). Replaced them with quoted real values.

## Verification

Ran a full `JEKYLL_ENV=production` build locally: all Liquid warnings and the SEO/alt warning are gone.

## Note

This branch is based off `main`, so it does **not** include the Hindi-post YAML front-matter fix (`_posts/hi/2026-03-27-model-context-protocol-python.md`) — that lives in #20. Jekyll skips that file with a non-fatal error and still exits 0, so it does not block CI here; it resolves once #20 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XwiZSmiMrvhMvWdx8H4HS9)_