### PR TITLE
Add ads.txt file with Google AdSense publisher ID

### DIFF
--- a/ads.txt
+++ b/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-7593038557752993, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
## Summary
This PR adds an `ads.txt` file to the repository to declare authorized digital ad sellers for this domain.

## Changes
- Added `ads.txt` file containing Google AdSense publisher verification entry
  - Specifies Google as an authorized direct seller
  - Includes publisher ID `pub-7593038557752993`
  - Includes authorization token for verification

## Details
The `ads.txt` file is a standard mechanism used to combat ad fraud and unauthorized inventory sales. This entry authorizes Google to sell ads on behalf of this domain directly.

https://claude.ai/code/session_01GTvvb2LHpHeBMSkXNK5w2U